### PR TITLE
Rewrite transform with rehype

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NOTION_TOKEN="xxxxxxxxxx"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.class
 node_modules
 build
+.env

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,14 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true
     },
+    "@types/hast": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
+      "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -64,6 +72,11 @@
         "@types/node": "*",
         "form-data": "^3.0.0"
       }
+    },
+    "@types/unist": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -287,6 +300,11 @@
         "follow-redirects": "^1.14.7"
       }
     },
+    "bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -316,6 +334,21 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
       "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
       "dev": true
+    },
+    "ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
+    },
+    "character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
+    },
+    "character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
     },
     "cheerio": {
       "version": "1.0.0-rc.10",
@@ -373,6 +406,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comma-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg=="
     },
     "commander": {
       "version": "2.20.3",
@@ -545,6 +583,11 @@
         "strip-final-newline": "^2.0.0"
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -627,6 +670,112 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "hast-util-embedded": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-2.0.0.tgz",
+      "integrity": "sha512-vEr54rDu2CheBM4nLkWbW8Rycf8HhkA/KsrDnlyKnvBTyhyO+vAG6twHnfUbiRGo56YeUBNCI4HFfHg3Wu+tig==",
+      "requires": {
+        "hast-util-is-element": "^2.0.0"
+      }
+    },
+    "hast-util-has-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-2.0.0.tgz",
+      "integrity": "sha512-4Qf++8o5v14us4Muv3HRj+Er6wTNGA/N9uCaZMty4JWvyFKLdhULrv4KE1b65AthsSO9TXSZnjuxS8ecIyhb0w=="
+    },
+    "hast-util-is-body-ok-link": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-1.0.4.tgz",
+      "integrity": "sha512-mFblNpLvFbD8dG2Nw5dJBYZkxIHeph1JAh5yr4huI7T5m8cV0zaXNiqzKPX/JdjA+tIDF7c33u9cxK132KRjyQ==",
+      "requires": {
+        "hast-util-has-property": "^1.0.0",
+        "hast-util-is-element": "^1.0.0"
+      },
+      "dependencies": {
+        "hast-util-has-property": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
+          "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg=="
+        },
+        "hast-util-is-element": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
+          "integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ=="
+        }
+      }
+    },
+    "hast-util-is-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-2.1.2.tgz",
+      "integrity": "sha512-thjnlGAnwP8ef/GSO1Q8BfVk2gundnc2peGQqEg2kUt/IqesiGg/5mSwN2fE7nLzy61pg88NG6xV+UrGOrx9EA==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "hast-util-parse-selector": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.0.tgz",
+      "integrity": "sha512-AyjlI2pTAZEOeu7GeBPZhROx0RHBnydkQIXlhnFzDi0qfXTmGUWoCYZtomHbrdrheV4VFUlPcfJ6LMF5T6sQzg==",
+      "requires": {
+        "@types/hast": "^2.0.0"
+      }
+    },
+    "hast-util-phrasing": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-2.0.0.tgz",
+      "integrity": "sha512-4rFSiFpdmTtp4aAxki6obpEbVJ85fOEN8/A8bOByoCaqRDTtd1AKTw3P/cXgVm0/RDuaWj0tSd1pTb0Jw5QfdA==",
+      "requires": {
+        "hast-util-embedded": "^2.0.0",
+        "hast-util-has-property": "^2.0.0",
+        "hast-util-is-body-ok-link": "^1.0.0",
+        "hast-util-is-element": "^2.0.0"
+      }
+    },
+    "hast-util-to-html": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.3.tgz",
+      "integrity": "sha512-/D/E5ymdPYhHpPkuTHOUkSatxr4w1ZKrZsG0Zv/3C2SRVT0JFJG53VS45AMrBtYk0wp5A7ksEhiC8QaOZM95+A==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "html-void-elements": "^2.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.2",
+        "unist-util-is": "^5.0.0"
+      }
+    },
+    "hast-util-whitespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz",
+      "integrity": "sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg=="
+    },
+    "hastscript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.0.2.tgz",
+      "integrity": "sha512-uA8ooUY4ipaBvKcMuPehTAB/YfFLSSzCwFSwT6ltJbocFUKH/GDHLN+tflq7lSRf9H86uOuxOFkh1KgIy3Gg2g==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^3.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      }
+    },
+    "html-void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
+      "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A=="
+    },
+    "html-whitespace-sensitive-tag-names": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-2.0.0.tgz",
+      "integrity": "sha512-SQdIvTTtnHAx72xGUIUudvVOCjeWvV1U7rvSFnNGxTGRw3ZC7RES4Gw6dm1nMYD60TXvm6zjk/bWqgNc5pjQaw=="
+    },
     "htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -665,6 +814,11 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
     },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+    },
     "is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
@@ -673,6 +827,11 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-plain-obj": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+      "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -762,6 +921,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "magicbook-codesplit": {
       "version": "0.1.6",
@@ -986,6 +1150,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "property-information": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
+      "integrity": "sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w=="
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1029,6 +1198,35 @@
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
+      }
+    },
+    "rehype-format": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-4.0.1.tgz",
+      "integrity": "sha512-HA92WeqFri00yiClrz54IIpM9no2DH9Mgy5aFmInNODoAYn+hN42a6oqJTIie2nj0HwFyV7JvOYx5YHBphN8mw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-embedded": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-phrasing": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "html-whitespace-sensitive-tag-names": "^2.0.0",
+        "rehype-minify-whitespace": "^5.0.0",
+        "unified": "^10.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      }
+    },
+    "rehype-minify-whitespace": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-5.0.1.tgz",
+      "integrity": "sha512-PPp4lWJiBPlePI/dv1BeYktbwkfgXkrK59MUa+tYbMPgleod+4DvFK2PLU0O0O60/xuhHfiR9GUIUlXTU8sRIQ==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-embedded": "^2.0.0",
+        "hast-util-is-element": "^2.0.0",
+        "hast-util-whitespace": "^2.0.0",
+        "unified": "^10.0.0",
+        "unist-util-is": "^5.0.0"
       }
     },
     "resolve": {
@@ -1129,6 +1327,11 @@
         "source-map": "^0.6.0"
       }
     },
+    "space-separated-tokens": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz",
+      "integrity": "sha512-ekwEbFp5aqSPKaqeY1PGrlGQxPNaq+Cnx4+bE2D8sciBQrHpbwoBbawqTN2+6jPs9IdWxxiUcN0K2pkczD3zmw=="
+    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1142,6 +1345,15 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "stringify-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.2.tgz",
+      "integrity": "sha512-MTxTVcEkorNtBbNpoFJPEh0kKdM6+QbMjLbaxmvaPMmayOXdr/AIVIIJX7FReUVweRBFJfZepK4A4AKgwuFpMQ==",
+      "requires": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
       }
     },
     "strip-final-newline": {
@@ -1222,10 +1434,61 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "trough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+      "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+    },
     "tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+      "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+    },
+    "unist-util-stringify-position": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+      "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+      "requires": {
+        "@types/unist": "^2.0.0"
+      }
+    },
+    "unist-util-visit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+      "integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+      "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^5.0.0"
+      }
     },
     "uri-js": {
       "version": "4.4.1",
@@ -1240,6 +1503,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "vfile": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.2.tgz",
+      "integrity": "sha512-w0PLIugRY3Crkgw89TeMvHCzqCs/zpreR31hl4D92y6SOE07+bfJe+dK5Q2akwS+i/c801kzjoOr9gMcTe6IAA==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      }
+    },
+    "vfile-message": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+      "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      }
     },
     "watchpack": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "@notionhq/client": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-0.4.13.tgz",
-      "integrity": "sha512-tHC95h4JZYteHmIL49xdta0Yb9q0peXySqo9cqTQEVzpPwUdcPNgWQljMqfrSVKqlpGNX+DhXztY0LR6f3Iw6A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-1.0.4.tgz",
+      "integrity": "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==",
       "requires": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.1"
@@ -57,9 +57,9 @@
       "integrity": "sha512-ydLaGVfQOQ6hI1xK2A5nVh8bl0OGoIfYMxPWHqqYe9bTkWCfqiVvZoh2I/QF2sNSkZzZyROBoTefIEI+PB6iIA=="
     },
     "@types/node-fetch": {
-      "version": "2.5.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -488,6 +488,11 @@
         "domhandler": "^4.2.0"
       }
     },
+    "dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
+    },
     "electron-to-chromium": {
       "version": "1.4.71",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "import-notion-docs": "node scripts/notion-html.js"
+    "import-notion-docs": "node scripts/import-notion-docs.js"
   },
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nature-of-code/noc-notion.git"
@@ -20,9 +21,14 @@
   "dependencies": {
     "@notionhq/client": "^1.0.4",
     "axios": "^0.25.0",
+    "hast-util-to-html": "^8.0.3",
+    "hastscript": "^7.0.2",
+    "lodash-es": "^4.17.21",
     "magicbook-codesplit": "^0.1.6",
     "magicbook-katex": "0.0.7",
-    "magicbook-webpack": "0.0.4"
+    "magicbook-webpack": "0.0.4",
+    "rehype-format": "^4.0.1",
+    "unist-util-visit": "^4.1.0"
   },
   "devDependencies": {
     "webpack": "^5.69.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@notionhq/client": "^1.0.4",
     "axios": "^0.25.0",
+    "dotenv": "^16.0.0",
     "hast-util-to-html": "^8.0.3",
     "hastscript": "^7.0.2",
     "lodash-es": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/nature-of-code/noc-notion#readme",
   "dependencies": {
-    "@notionhq/client": "^0.4.13",
+    "@notionhq/client": "^1.0.4",
     "axios": "^0.25.0",
     "magicbook-codesplit": "^0.1.6",
     "magicbook-katex": "0.0.7",

--- a/scripts/import-notion-docs.js
+++ b/scripts/import-notion-docs.js
@@ -1,0 +1,54 @@
+import { promises as fs } from 'fs';
+import { snakeCase } from 'lodash-es';
+import { toHtml } from 'hast-util-to-html';
+import rehypeFormat from 'rehype-format';
+
+import { getPageId, fetchBlockChildren } from './lib/notion-api.js';
+import { fromNotion } from './lib/hast-from-notion.js';
+
+const DESTINATION_FOLDER = 'src/chapter-content/';
+const ROOT_BLOCK_NAME = 'Content';
+
+const formatHast = rehypeFormat();
+
+main();
+
+async function main() {
+  console.log(`Deleting ${DESTINATION_FOLDER}`);
+  await fs.rmdir(DESTINATION_FOLDER, { recursive: true });
+
+  console.log(`Creating ${DESTINATION_FOLDER}`);
+  await fs.mkdir(DESTINATION_FOLDER, {});
+
+  const rootId = await getPageId(ROOT_BLOCK_NAME);
+  const rootContent = await fetchBlockChildren({
+    blockId: rootId,
+  });
+
+  // Import all pages under the root page
+  rootContent
+    .filter((block) => block.type === 'child_page')
+    .forEach(async (page) => {
+      await importPage({
+        pageId: page.id,
+        title: page.child_page.title,
+      });
+    });
+}
+
+async function importPage({ pageId, title }) {
+  // Get all page content recursively
+  const pageContent = await fetchBlockChildren({
+    blockId: pageId,
+    recursive: true,
+  });
+
+  // Transform Notion content to hast
+  const hast = fromNotion(pageContent, title);
+  // Format using plugin
+  formatHast(hast);
+
+  const fileName = `${snakeCase(title)}.html`;
+  console.log('Creating file', fileName);
+  await fs.writeFile(`${DESTINATION_FOLDER}/${fileName}`, toHtml(hast));
+}

--- a/scripts/lib/hast-from-notion.js
+++ b/scripts/lib/hast-from-notion.js
@@ -47,6 +47,7 @@ function transform(block) {
     case 'paragraph':
       return h('p', block.paragraph.rich_text.map(transformText));
     case 'image':
+      if (block.image.type !== 'external') return null;
       const className = block.image.caption
         .filter(({ annotations }) => annotations.code)
         .map(({ text }) => text.content)

--- a/scripts/lib/hast-from-notion.js
+++ b/scripts/lib/hast-from-notion.js
@@ -1,0 +1,195 @@
+import { h } from 'hastscript';
+import { visit } from 'unist-util-visit';
+
+/**
+ * Transform a Notion tree to a hast tree
+ *
+ * @param {Array<NotionBlock>} blocks
+ * @param {String} title
+ * @returns {HastNode}
+ */
+export function fromNotion(blocks, title) {
+  const hast = h('section', [h('h1', title), ...blocks.map(transform)]);
+
+  // Merge ordered & unordered list items
+  visit(hast, { tagName: 'ol' }, (node, index, parent) => {
+    while (
+      parent.children[index + 1] &&
+      parent.children[index + 1].tagName === 'ol'
+    ) {
+      node.children.push(parent.children[index + 1].children[0]);
+      parent.children.splice(index + 1, 1);
+    }
+  });
+  visit(hast, { tagName: 'ul' }, (node, index, parent) => {
+    while (
+      parent.children[index + 1] &&
+      parent.children[index + 1].tagName === 'ul'
+    ) {
+      node.children.push(parent.children[index + 1].children[0]);
+      parent.children.splice(index + 1, 1);
+    }
+  });
+
+  return hast;
+}
+
+/**
+ * @param {NotionBlock} block
+ * @returns {HastNode}
+ */
+function transform(block) {
+  switch (block.type) {
+    case 'heading_2':
+      return h('h2', block.heading_2.rich_text.map(transformText));
+    case 'heading_3':
+      return h('h3', block.heading_3.rich_text.map(transformText));
+    case 'paragraph':
+      return h('p', block.paragraph.rich_text.map(transformText));
+    case 'image':
+      const className = block.image.caption
+        .filter(({ annotations }) => annotations.code)
+        .map(({ text }) => text.content)
+        .join(' ');
+      const caption = block.image.caption
+        .filter(({ annotations }) => !annotations.code)
+        .map(transformText);
+
+      return h('figure', { class: className || null }, [
+        h('img', { src: block.image.external.url, alt: caption }),
+        h('figcaption', caption),
+      ]);
+    case 'quote':
+      const children = block.has_children ? block.children.map(transform) : [];
+      return h('blockquote', { dataType: 'epigraph' }, [
+        h('p', block.quote.rich_text.map(transformText)),
+        ...children,
+      ]);
+    case 'equation':
+      return h('div', { dataType: 'equation' }, block.equation.expression);
+    case 'code':
+      return h(
+        'pre.codesplit',
+        { dataCodeLanguage: block.code.language },
+        block.code.rich_text.map(transformText),
+      );
+
+    // List
+    // wrap every list item in a list tag which will be removed & merged later
+    case 'bulleted_list_item':
+      return h('ul', [
+        h('li', block.bulleted_list_item.rich_text.map(transformText)),
+      ]);
+    case 'numbered_list_item':
+      return h('ol', [
+        h('li', block.numbered_list_item.rich_text.map(transformText)),
+      ]);
+
+    // Table
+    case 'table':
+      return h(
+        'table',
+        h(
+          'tbody',
+          block.children.map((row) => {
+            return h(
+              'tr',
+              row.table_row.cells.map((cell) =>
+                h('td', cell.map(transformText)),
+              ),
+            );
+          }),
+        ),
+      );
+
+    // Customized blocks
+    case 'callout':
+      return transformCustomizedBlock(block);
+
+    default:
+      console.warn('missing handler for type:', block.type);
+      return null;
+  }
+}
+
+/**
+ * @param {NotionRichText} richText
+ * @returns {HastNode}
+ */
+function transformText(richText) {
+  switch (richText.type) {
+    case 'text':
+      let { content } = richText.text;
+
+      if (richText.annotations.italic) {
+        content = h('em', content);
+      }
+      if (richText.annotations.bold) {
+        content = h('strong', content);
+      }
+      if (richText.annotations.code) {
+        content = h('code', content);
+      }
+      return content;
+
+    case 'equation':
+      return h('span', { dataType: 'equation' }, richText.equation.expression);
+
+    default:
+      console.warn('missing handler for rich_text:', richText.type);
+      return null;
+  }
+}
+
+/**
+ * @param {NotionBlock} block
+ * @returns {HastNode}
+ */
+function transformCustomizedBlock(block) {
+  const children = block.has_children ? block.children.map(transform) : [];
+
+  switch (block.callout.icon.emoji) {
+    // Indexterm
+    case '🔗':
+      const terms = block.callout.rich_text[0].text.content.split(' / ');
+      const attributes = {
+        dataType: 'indexterm',
+        dataPrimary: terms[0],
+      };
+      if (terms.length > 1) attributes.dataSecondary = terms[1];
+      if (terms.length > 2) attributes.dataTertiary = terms[2];
+
+      return h('a', attributes);
+
+    // Highlight
+    case '💡':
+      return h('p', [
+        h('span.highlight', block.callout.rich_text.map(transformText)),
+      ]);
+
+    // Note
+    case '📒':
+      return h('div', { dataType: 'note' }, [
+        h('h5', block.callout.rich_text[0].text.content),
+        ...children,
+      ]);
+
+    // Exercise
+    case '✏️':
+      return h('div', { dataType: 'exercise' }, [
+        h('h5', block.callout.rich_text[0].text.content),
+        ...children,
+      ]);
+
+    // Project
+    case '🦎':
+      return h('div', { dataType: 'project' }, [
+        h('h5', block.callout.rich_text[0].text.content),
+        ...children,
+      ]);
+
+    default:
+      console.warn('missing handler for callout:', block.callout.icon.emoji);
+      return null;
+  }
+}

--- a/scripts/lib/notion-api.js
+++ b/scripts/lib/notion-api.js
@@ -1,0 +1,50 @@
+import { Client } from '@notionhq/client';
+
+const notion = new Client({ auth: process.env.NOTION_TOKEN });
+
+export async function getPageId(query) {
+  const response = await notion.search({ query });
+  if (!response.results.length) {
+    throw `"${blockName}" not found`;
+  }
+
+  return response.results[0].id;
+}
+
+export async function fetchBlockChildren({
+  blockId,
+  startCursor,
+  recursive = false,
+}) {
+  console.log('Fetching', blockId, startCursor ? `@ ${startCursor}` : '');
+  const response = await notion.blocks.children.list({
+    block_id: blockId,
+    start_cursor: startCursor,
+    page_size: 100,
+  });
+
+  const blockChildren = response.results;
+
+  if (!recursive) return blockChildren;
+
+  for (let i = 0; i < blockChildren.length; i++) {
+    if (blockChildren[i].has_children) {
+      blockChildren[i].children = await fetchBlockChildren({
+        blockId: blockChildren[i].id,
+        recursive: true,
+      });
+    }
+  }
+
+  if (response.has_more) {
+    const nextBlockChildren = await fetchBlockChildren({
+      blockId,
+      startCursor: response.next_cursor,
+      recursive: true,
+    });
+
+    blockChildren.push(...nextBlockChildren);
+  }
+
+  return blockChildren;
+}

--- a/scripts/lib/notion-api.js
+++ b/scripts/lib/notion-api.js
@@ -1,4 +1,5 @@
 import { Client } from '@notionhq/client';
+import 'dotenv/config';
 
 const notion = new Client({ auth: process.env.NOTION_TOKEN });
 


### PR DESCRIPTION
Hey, I rewrite the transform with `rehype` and implement most block types.
The new script is called `import-notion-docs.js` along with `lib/hast-from-notion.js` and `notion-api.js`. It first gets all the page content recursively and parses them to a hast tree which will then be stringified to HTML files.

## New dependencies
- `hast-util-to-html`: stringify hast to HTML
- `hastscript`: utility to create hast trees
- `rehype-format`: format hast tree
- `unist-util-visit`: utility to visit node
- `lodash-es`: import `snakeCase` for filename
- `dotenv`: env variables

## Other changes
- `hast` plugins only support ES6 modules, so an extra line `"type": "module"` is added in `package.json`
- I use `Prettier` for formatting javascript and include a config file`.prettierrc`. Do you have different preferences over tools and styling options?
- Update `@notionhq/client` version to the latest stable for `table` support