### PR TITLE
Remove floating images' top margin

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,7 +6,7 @@
 @tailwind utilities;
 
 .half-width-right {
-  @apply md:w-[50%] md:float-right md:ml-4;
+  @apply md:w-[50%] md:float-right md:ml-4 md:mt-0;
 }
 
 .math-display {


### PR DESCRIPTION
Floating illustrations should align vertically to the paragraph next to.