### PR TITLE
Increase pdf build timeout

### DIFF
--- a/magicbook.json
+++ b/magicbook.json
@@ -1,5 +1,8 @@
 {
   "title": "Nature of Code",
+  "prince": {
+    "timeout": 60000
+  },
   "addPlugins": [
     "magicbook-codesplit",
     "magicbook-katex",


### PR DESCRIPTION
Increased the prince build timeout to 60,000 (60s), since the default 10s is not enough as content grow.

This may be related to #264.