### PR TITLE
Add examples page to showcase embedded sketches

### DIFF
--- a/gatsby/create-pages.js
+++ b/gatsby/create-pages.js
@@ -45,4 +45,12 @@ module.exports = async ({ graphql, actions, reporter }) => {
       });
     });
   }
+
+  // Create the example page (contains every embedded sketch with screenshot)
+  if (process.env.CREATE_EXAMPLES_PAGE === 'true') {
+    createPage({
+      path: '/examples',
+      component: path.resolve(`./src/layouts/ExamplesPageLayout.js`),
+    });
+  }
 };

--- a/src/components/Example.js
+++ b/src/components/Example.js
@@ -13,7 +13,7 @@ const EMBED_MAX_HEIGHT = 432;
 const Example = (data) => {
   const ref = React.useRef(null);
   const [loaded, setLoaded] = React.useState(false);
-  const [isLooping, setIsLooping] = React.useState(true);
+  const [isLooping, setIsLooping] = React.useState(!data.pauseAtBeginning);
   const [aspectRatio, setAspectRatio] = React.useState(8 / 3);
   const [canvasWidth, setCanvasWidth] = React.useState(768);
 
@@ -31,6 +31,11 @@ const Example = (data) => {
       p5Window.document.body.style.overflow = 'hidden';
 
       const p5Canvas = p5Window.document.querySelector('canvas');
+
+      if (data.pauseAtBeginning) {
+        p5Window.noLoop();
+        setIsLooping(false);
+      }
 
       // if the canvas is already created, adjust it.
       if (p5Canvas) {

--- a/src/layouts/ExamplesPageLayout.js
+++ b/src/layouts/ExamplesPageLayout.js
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { graphql } from 'gatsby';
+import { unified } from 'unified';
+import { h } from 'hastscript';
+import { visit } from 'unist-util-visit';
+import rehypeReact from 'rehype-react';
+
+import Head from '../components/Head';
+import Header from '../components/Header';
+import Example from '../components/Example';
+
+const renderAst = (ast) => {
+  const examples = [];
+  visit(ast, { tagName: 'embed-example' }, (node) => {
+    examples.push(node);
+  });
+
+  const tree = h(
+    'div',
+    examples.map((node) => {
+      node.properties.pauseAtBeginning = true;
+
+      return h(
+        'div',
+        {
+          style: {
+            border: '1px dotted black',
+            margin: '12px 0',
+            padding: '0 16px',
+          },
+        },
+        [
+          h(
+            'p',
+            {
+              style: {
+                fontWeight: 'bold',
+              },
+            },
+            node.properties.dataExamplePath,
+          ),
+          node,
+          h('img', {
+            class: 'border',
+            src: `/${node.properties.dataExamplePath}/screenshot.png`,
+            alt: 'screenshot',
+          }),
+        ],
+      );
+    }),
+  );
+
+  const processor = unified().use(rehypeReact, {
+    createElement: React.createElement,
+    Fragment: React.Fragment,
+    components: {
+      'embed-example': Example,
+    },
+  });
+
+  return processor.stringify(tree);
+};
+
+export default function ExamplesPage({ data }) {
+  return (
+    <>
+      <Head />
+
+      <Header />
+
+      <div className="py-8 max-w-[676px] prose mx-auto">
+        {data.allChaptersJson.edges.map(({ node }) => {
+          const { htmlAst } = node.src.fields;
+
+          return (
+            <div key={node.src.id}>
+              <h3>{node.title}</h3>
+              {renderAst(JSON.parse(htmlAst))}
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+export const query = graphql`
+  query AllExample {
+    allChaptersJson {
+      edges {
+        node {
+          title
+          src {
+            id
+            fields {
+              htmlAst
+            }
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
This PR introduces a new page at `/examples` to the Gatsby build, which features all the embedded sketches alongside their respective screenshots. To ensure smooth operation, all embedded sketches will be paused at the beginning by default.

Additionally, this feature can be toggled on and off (default to off) using the environment variable `CREATE_EXAMPLES_PAGE` which I have set to `true` on Netlify.

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/6762203/232859916-fbfabfe6-8833-45ba-bd35-111dd63aa0c2.png">