### PR TITLE
fix screenshot image background color

### DIFF
--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -93,6 +93,7 @@ figure {
     display: block;
     width: 100%;
     margin: 0;
+    background-color: white;
   }
 
   figcaption:not(:empty) {


### PR DESCRIPTION
Fixed the inconsistent grayscale in screenshot images by adding a white background in image CSS.


<img width="853" alt="Screenshot 2023-08-04 at 12 44 40 PM" src="https://github.com/nature-of-code/noc-book-2023/assets/90000947/8b69f5ac-a38d-461a-a9f8-5cdfc1b8110f">

