### PR TITLE
Fill in the Blank PDF CSS

### DIFF
--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -72,5 +72,7 @@
 
   span.blank {
     color: transparent;
+    font-size:11pt;
+    line-height:16pt;
   }
 }


### PR DESCRIPTION
Relate #352 

I also increased the line height a bit, so that they may have more space to write in -

<img width="775" alt="Screenshot 2023-08-09 at 8 42 26 PM" src="https://github.com/nature-of-code/noc-book-2023/assets/90000947/2ed7e02a-950d-4ecf-9c82-0c1d1ab7de52">

<img width="725" alt="Screenshot 2023-08-09 at 8 42 08 PM" src="https://github.com/nature-of-code/noc-book-2023/assets/90000947/fc829cb4-7cd8-4050-9d70-cb921883f334">

