### PR TITLE
CSS update for monospace font size

### DIFF
--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -1,5 +1,5 @@
 .codesplit {
-  font-size: 7.5pt;
+  font-size: 8.5pt;
   line-height: 13pt;
 
   .pair {

--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -72,7 +72,7 @@
 
   span.blank {
     color: transparent;
-    font-size: 11pt;
-    line-height: 16pt;
+    font-size: 13pt;
+    line-height: 18pt;
   }
 }

--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -50,7 +50,7 @@ code {
 }
 
 code:not(pre code) {
-  font-size: 7.5pt;
+  font-size: 8.5pt;
   line-height: 12pt;
   display: inline-block;
   background-color: $color-gray-200;


### PR DESCRIPTION
I fixed the font size issue Dan mentioned in previous pull request -

Current version
<img width="677" alt="Screenshot 2023-08-16 at 1 42 45 AM" src="https://github.com/nature-of-code/noc-book-2023/assets/90000947/43f85060-4a0f-4762-98eb-995c33a16ce4">

Previous version
<img width="583" alt="Screenshot 2023-08-16 at 1 39 44 AM" src="https://github.com/nature-of-code/noc-book-2023/assets/90000947/fc38a2b3-821d-4938-b895-6223b8357931">
