### PR TITLE
Update list indentation

### DIFF
--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -74,7 +74,8 @@ a {
 ol,
 ul {
   padding-left: 0;
-  margin: 0 5mm;
+  margin: 0 10mm;
+  list-style-position: outside; 
 
   li {
     font-size: 8pt;


### PR DESCRIPTION
Relate #351 

Also updated the list-style-position so that when the text switch lines, it aligns correctly with the previous line (instead of aligning to the bullet points)

![Screenshot 2023-08-22 at 5 38 04 PM](https://github.com/nature-of-code/noc-book-2023/assets/90000947/180ec90a-20e8-4511-8378-028f73a8e2a7)
