### PR TITLE
Pause examples outside viewport (perf improvement)

### DIFF
--- a/src/components/Example.js
+++ b/src/components/Example.js
@@ -93,6 +93,28 @@ const Example = (data) => {
     return () => window.removeEventListener('resize', handleWindowResize);
   }, []);
 
+  React.useEffect(() => {
+    // start and stop the p5 example loop based on visibility
+    const curr = ref.current;
+    if (!curr || !loaded || !isLooping) return;
+
+    const intersectionCallback = (entries) => {
+      const p5Window = curr.contentWindow;
+      const [entry] = entries;
+      entry.isIntersecting ? p5Window.loop() : p5Window.noLoop();
+    };
+
+    const observer = new IntersectionObserver(intersectionCallback, {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0,
+    });
+
+    observer.observe(curr);
+
+    return () => observer.unobserve(curr);
+  }, [ref, isLooping, loaded]);
+
   return (
     <div
       className="not-prose my-4 clear-both rounded overflow-hidden border bg-gray-100"


### PR DESCRIPTION
Hey @shiffman - hope you're well!

Caught up to your live stream where you mentioned there were performance issues when all examples were running on a page.

The [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) can tell us when DOM elements come in and out of the viewport, so we can start and stop the example's p5 loop accordingly. Examples that were manually paused will remain paused when they become visible again.

Let me know if this improves the situation for you.