### PR TITLE
Properly hide example loading message DOM element

### DIFF
--- a/src/components/Example.js
+++ b/src/components/Example.js
@@ -103,7 +103,7 @@ const Example = (data) => {
       <div className="bg-white relative rounded-t overflow-hidden">
         <div
           className={`absolute top-[50%] left-[50%] -translate-x-[50%] -translate-y-[50%] ${
-            loaded ? 'opacity-0' : ' opacity-100'
+            loaded ? 'hidden' : ''
           }`}
         >
           Loading sketch ...


### PR DESCRIPTION
The `Loading sketch...` loading message on top of examples is only hidden by lowering the opacity, which means the element still renders on the page and can capture mouse events. It is especially problematic for sketches that track mouse movement like "Example 1.3: Vector Subtraction" in the "Vectors" chapter.

**Before**

https://github.com/nature-of-code/noc-book-2023/assets/4009209/0a3d2891-4c3d-4684-b773-0830861253d4

**After**

https://github.com/nature-of-code/noc-book-2023/assets/4009209/eecacdf9-63b5-4a8f-98be-dc40c39f81bb

