### PR TITLE
Updating the <strong> tag css for codesplit

### DIFF
--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -66,13 +66,13 @@
     }
   }
 
-  .bold {
-    font-weight: 700;
-  }
-
   span.blank {
     color: transparent;
     font-size: 13pt;
     line-height: 18pt;
+  }
+
+  strong{
+    font-weight: 700;
   }
 }


### PR DESCRIPTION
As @shiffman mentioned in Notion, there was a line in Chapter 3 that was rendered italic instead of bold in the pdf. It was originally marked up as `<strong><em>`, so I fixed the markup in Notion, and went in CSS to further define the `<strong>` tag in codesplit.scss. Also, I took out the `.bold` class in CSS since it wasn't used anywhere in the consolidated.html.

The line mentioned in Notion -
![Screenshot 2023-08-29 at 3 07 30 PM](https://github.com/nature-of-code/noc-book-2023/assets/90000947/8b937cd6-1e32-4d6d-9b17-0096a921677d)


updated PDF render -
![Screenshot 2023-08-29 at 3 13 43 PM](https://github.com/nature-of-code/noc-book-2023/assets/90000947/08e58c7c-a6d7-4624-8f69-3d5a7cbdc6c7)
