### PR TITLE
Fix the styles when the floating image is larger than the text

### DIFF
--- a/magicbook/stylesheets/components/callout.scss
+++ b/magicbook/stylesheets/components/callout.scss
@@ -5,6 +5,11 @@ div[data-type='project'],
 div[data-type='example'] {
   margin: 1.5em 0;
   page-break-inside: avoid;
+  overflow: auto;
+
+  figure {
+    margin: 0;
+  }
 }
 
 span.highlight {

--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -115,13 +115,13 @@ figure {
 .half-width-right {
   float: right;
   margin-left: 2em;
-  width: 50%;
+  max-width: 50%;
 }
 
 .half-width-left {
   float: left;
   margin-right: 2em;
-  width: 50%;
+  max-width: 50%;
 }
 
 // column list

--- a/src/styles/callout.css
+++ b/src/styles/callout.css
@@ -1,5 +1,5 @@
 .callout {
-  @apply bg-gray-100 rounded py-4 my-4 clear-both;
+  @apply bg-gray-100 rounded py-4 my-4 clear-both overflow-auto;
 }
 
 .callout:not(.codesplit) {
@@ -13,6 +13,10 @@
 
 .callout > h3:first-child {
   @apply mt-2;
+}
+
+.callout figure {
+  @apply my-0;
 }
 
 .highlight {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,11 +6,11 @@
 @tailwind utilities;
 
 .half-width-right {
-  @apply md:w-[50%] md:float-right md:ml-5 md:mt-0;
+  @apply md:max-w-[50%] md:float-right md:ml-5 md:mt-0;
 }
 
 .half-width-left {
-  @apply md:w-[50%] md:float-left md:mr-5 md:mt-0;
+  @apply md:max-w-[50%] md:float-left md:mr-5 md:mt-0;
 }
 
 .math-display {


### PR DESCRIPTION
Fix of #299

## Results

***Website***

![image](https://github.com/nature-of-code/noc-book-2023/assets/6762203/8b244cb2-9591-4c08-a8d9-dbe60fbc7be8)

![image](https://github.com/nature-of-code/noc-book-2023/assets/6762203/44cc03f1-b715-4412-af8e-1c9593f12f61)

***PDF***

![image](https://github.com/nature-of-code/noc-book-2023/assets/6762203/8851f505-ceeb-429e-aa64-2408678b0a64)

Noted The image in `Exercise 8.6` is still a bit large

![image](https://github.com/nature-of-code/noc-book-2023/assets/6762203/e0000e4f-a4d4-4b42-8743-0a5e395e99ee)
