### PR TITLE
Remove css grayscale filter

### DIFF
--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -96,7 +96,6 @@ figure {
   page-break-inside: avoid;
 
   img {
-    filter: grayscale(100);
     display: block;
     width: 100%;
     margin: 0;


### PR DESCRIPTION
Fix of #383 

The grayscale image filters are degrading the image quality. They can be safely removed since we have added the color space transformation step before the Prince XML build.