### PR TITLE
Align `image in exercise` to the heading

### DIFF
--- a/magicbook/stylesheets/components/callout.scss
+++ b/magicbook/stylesheets/components/callout.scss
@@ -33,6 +33,10 @@ div[data-type='exercise'] {
       margin-right: 4pt;
     }
   }
+
+  h3 + .half-width-right {
+    margin-top: -12pt;
+  }
 }
 
 div[data-type='note'],


### PR DESCRIPTION
Add negative top margin to align the right after floating image inside exercises to the heading.

Ref: https://github.com/nature-of-code/noc-book-2023/issues/299#issuecomment-1699655941

![image](https://github.com/nature-of-code/noc-book-2023/assets/6762203/906ece8f-de9c-4c5d-aabd-b53d24c64410)