### PR TITLE
Improve the pause and resume behavior of examples

### DIFF
--- a/src/components/Example.js
+++ b/src/components/Example.js
@@ -38,6 +38,7 @@ const Example = (data) => {
         const nextFrameCallback = () => {
           if (p5Window.frameRate?.() > 0) {
             pause();
+            setIsRunning(false);
           } else {
             window.requestAnimationFrame(nextFrameCallback);
           }
@@ -68,36 +69,34 @@ const Example = (data) => {
   };
 
   const toggleRunning = () => {
-    isRunning ? pause() : resume();
+    if (isRunning) {
+      pause();
+      setIsRunning(false);
+    } else {
+      resume();
+      setIsRunning(true);
+    }
   };
 
-  const pause = React.useCallback(
-    (updateIsRunning = true) => {
-      if (!ref.current) return;
-      const p5Window = ref.current.contentWindow;
+  const pause = React.useCallback(() => {
+    if (!ref.current) return;
+    const p5Window = ref.current.contentWindow;
 
-      const targetFrameRate = p5Window.getTargetFrameRate?.();
-      if (targetFrameRate > 0) {
-        p5Window.frameRate(0);
-        setPausedFrameRate(targetFrameRate);
-        if (updateIsRunning) setIsRunning(false);
-      }
-    },
-    [ref],
-  );
+    const targetFrameRate = p5Window.getTargetFrameRate?.();
+    if (targetFrameRate > 0 && p5Window.frameRate) {
+      p5Window.frameRate(0);
+      setPausedFrameRate(targetFrameRate);
+    }
+  }, [ref]);
 
-  const resume = React.useCallback(
-    (updateIsRunning = true) => {
-      if (!ref.current) return;
-      const p5Window = ref.current.contentWindow;
+  const resume = React.useCallback(() => {
+    if (!ref.current) return;
+    const p5Window = ref.current.contentWindow;
 
-      if (pausedFrameRate > 0 && p5Window.frameRate) {
-        p5Window.frameRate(pausedFrameRate);
-        if (updateIsRunning) setIsRunning(true);
-      }
-    },
-    [ref, pausedFrameRate],
-  );
+    if (pausedFrameRate > 0 && p5Window.frameRate) {
+      p5Window.frameRate(pausedFrameRate);
+    }
+  }, [ref, pausedFrameRate]);
 
   // Fix for: iframe's load event triggered before component being mounted
   // reference: https://github.com/facebook/react/issues/6541
@@ -133,7 +132,7 @@ const Example = (data) => {
       if (entries.length % 2 === 0) return;
 
       const entry = entries.at(-1);
-      entry.isIntersecting ? resume(false) : pause(false);
+      entry.isIntersecting ? resume() : pause();
     };
 
     const observer = new IntersectionObserver(intersectionCallback, {

--- a/src/components/Example.js
+++ b/src/components/Example.js
@@ -13,9 +13,10 @@ const EMBED_MAX_HEIGHT = 432;
 const Example = (data) => {
   const ref = React.useRef(null);
   const [loaded, setLoaded] = React.useState(false);
-  const [isLooping, setIsLooping] = React.useState(!data.pauseAtBeginning);
+  const [isRunning, setIsRunning] = React.useState(!data.pauseAtBeginning);
   const [aspectRatio, setAspectRatio] = React.useState(8 / 3);
   const [canvasWidth, setCanvasWidth] = React.useState(768);
+  const [pausedFrameRate, setPausedFrameRate] = React.useState(0);
 
   const adjustFrame = (canvas) => {
     setAspectRatio(canvas.width / canvas.height);
@@ -32,9 +33,16 @@ const Example = (data) => {
 
       const p5Canvas = p5Window.document.querySelector('canvas');
 
-      if (data.pauseAtBeginning) {
-        p5Window.noLoop();
-        setIsLooping(false);
+      if (data.pauseAtBeginning || !isRunning) {
+        // allow p5 to render something before pausing so we don't have a blank sketch
+        const nextFrameCallback = () => {
+          if (p5Window.frameRate?.() > 0) {
+            pause();
+          } else {
+            window.requestAnimationFrame(nextFrameCallback);
+          }
+        };
+        window.requestAnimationFrame(nextFrameCallback);
       }
 
       // if the canvas is already created, adjust it.
@@ -52,32 +60,54 @@ const Example = (data) => {
   };
 
   const reset = () => {
-    if (ref.current) {
-      const p5Window = ref.current.contentWindow;
-      p5Window.location.reload();
-      setIsLooping(true);
-    }
+    if (!ref.current) return;
+    const p5Window = ref.current.contentWindow;
+
+    p5Window.location.reload();
+    setIsRunning(true);
   };
 
-  const toggleLoop = () => {
-    if (ref.current) {
-      const p5Window = ref.current.contentWindow;
-      if (isLooping) {
-        p5Window.noLoop();
-        setIsLooping(false);
-      } else {
-        p5Window.loop();
-        setIsLooping(true);
-      }
-    }
+  const toggleRunning = () => {
+    isRunning ? pause() : resume();
   };
+
+  const pause = React.useCallback(
+    (updateIsRunning = true) => {
+      if (!ref.current) return;
+      const p5Window = ref.current.contentWindow;
+
+      const targetFrameRate = p5Window.getTargetFrameRate?.();
+      if (targetFrameRate > 0) {
+        p5Window.frameRate(0);
+        setPausedFrameRate(targetFrameRate);
+        if (updateIsRunning) setIsRunning(false);
+      }
+    },
+    [ref],
+  );
+
+  const resume = React.useCallback(
+    (updateIsRunning = true) => {
+      if (!ref.current) return;
+      const p5Window = ref.current.contentWindow;
+
+      if (pausedFrameRate > 0 && p5Window.frameRate) {
+        p5Window.frameRate(pausedFrameRate);
+        if (updateIsRunning) setIsRunning(true);
+      }
+    },
+    [ref, pausedFrameRate],
+  );
 
   // Fix for: iframe's load event triggered before component being mounted
   // reference: https://github.com/facebook/react/issues/6541
   React.useEffect(() => {
-    if (ref.current) {
-      ref.current.src = `/${data['data-example-path']}`;
-    }
+    if (!ref.current) return;
+
+    setLoaded(false);
+    ref.current.src = `/${data['data-example-path']}`;
+
+    return () => setLoaded(false);
   }, [data]);
 
   const handleWindowResize = () => {
@@ -96,12 +126,14 @@ const Example = (data) => {
   React.useEffect(() => {
     // start and stop the p5 example loop based on visibility
     const curr = ref.current;
-    if (!curr || !loaded || !isLooping) return;
+    if (!curr || !loaded || !isRunning) return;
 
     const intersectionCallback = (entries) => {
-      const p5Window = curr.contentWindow;
-      const [entry] = entries;
-      entry.isIntersecting ? p5Window.loop() : p5Window.noLoop();
+      // even amount of entries imply no-op (fast scroll skipped over the element)
+      if (entries.length % 2 === 0) return;
+
+      const entry = entries.at(-1);
+      entry.isIntersecting ? resume(false) : pause(false);
     };
 
     const observer = new IntersectionObserver(intersectionCallback, {
@@ -113,7 +145,7 @@ const Example = (data) => {
     observer.observe(curr);
 
     return () => observer.unobserve(curr);
-  }, [ref, isLooping, loaded]);
+  }, [ref, isRunning, loaded, resume, pause]);
 
   return (
     <div
@@ -157,9 +189,9 @@ const Example = (data) => {
 
           <button
             className="flex items-center px-2.5 py-1.5 text-sm hover:bg-gray-200 border-r"
-            onClick={toggleLoop}
+            onClick={toggleRunning}
           >
-            {isLooping ? (
+            {isRunning ? (
               <>
                 <HiOutlinePause className="h-4 w-4" />
                 {canvasWidth > 320 && <span className="ml-1">Pause</span>}


### PR DESCRIPTION
Noticed a few issues with the embedded examples:
- When scrolling very fast (easily reproduced when clicking anchors and scroll a long distance), the iframes unload and reload and would cause runtime errors when we try to pause/resume the examples that are not visible
- Again when fast scrolling, the paused state of an example would not be preserved
- Some examples use `noLoop()` to stop their draw function, but this was also the mechanism used by the website to pause and resume sketches. Pausing and resuming one of these examples would cause overdraws and break their state.

This PR should address all these problems by properly detecting the unload/reload states on fast scroll, and by manipulating the sketch's frame rate to pause and resume instead of using noLoop() / loop().

Here are some screen recordings of the problems

https://github.com/nature-of-code/noc-book-2023/assets/4009209/54ac999e-938a-4d2a-8930-2a96b8df06a9

https://github.com/nature-of-code/noc-book-2023/assets/4009209/70b10131-e37d-4c62-9c9b-c5b5d9897cc1

https://github.com/nature-of-code/noc-book-2023/assets/4009209/5caa68c9-5517-4051-aaea-5ae868c3f649

And fixes:

https://github.com/nature-of-code/noc-book-2023/assets/4009209/2645f9d1-b3ab-467a-a5d3-ceea90bc9a3e





