### PR TITLE
Fix chapter opening quote italic

### DIFF
--- a/magicbook/stylesheets/components/chapter-opening.scss
+++ b/magicbook/stylesheets/components/chapter-opening.scss
@@ -38,9 +38,12 @@
         margin: 0.25rem 0;
         font-style: italic;
       }
-      
+
       .chapter-opening-quote-source{
-        font-style:normal;
+
+        p{
+          font-style: normal;
+        }
       }
     }
   }

--- a/magicbook/stylesheets/components/chapter-opening.scss
+++ b/magicbook/stylesheets/components/chapter-opening.scss
@@ -39,9 +39,8 @@
         font-style: italic;
       }
 
-      .chapter-opening-quote-source{
-
-        p{
+      .chapter-opening-quote-source {
+        p {
           font-style: normal;
         }
       }

--- a/magicbook/stylesheets/components/chapter-opening.scss
+++ b/magicbook/stylesheets/components/chapter-opening.scss
@@ -38,6 +38,10 @@
         margin: 0.25rem 0;
         font-style: italic;
       }
+      
+      .chapter-opening-quote-source{
+        font-style:normal;
+      }
     }
   }
 


### PR DESCRIPTION
I added another markup tag in Notion and defined the style in chapter-opening.scss. Currently, I only updated the chapter 0: randomness on Notion and is rendering correctly as screenshot. If this looks okay, we can merge this branch, and I can make changes for other chapters in Notion as well.

Notion:
<img width="872" alt="Screenshot 2023-12-13 at 4 35 26 PM" src="https://github.com/nature-of-code/noc-book-2023/assets/90000947/1dc4abed-2063-4f67-a187-1d337b208c90">

PDF render:
<img width="695" alt="Screenshot 2023-12-13 at 4 35 36 PM" src="https://github.com/nature-of-code/noc-book-2023/assets/90000947/095d3f0d-9417-4a0e-8755-d4d68ee2e409">
