### PR TITLE
Render `href` in pdf build

### DIFF
--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -78,6 +78,11 @@ a {
   &:not([href^='http'])::after {
     content: ' (see page ' target-counter(attr(href), page) ')';
   }
+
+  // External links
+  &[href^='http']::after {
+    content: ' (' attr(href) ')';
+  }
 }
 
 ol,


### PR DESCRIPTION
Adding back the href render feature, #582 

Please note that if links are included in the content, they may be displayed twice. For example:

> For details, see the pixel array video tutorial in the “Pixels" track on the Coding Train website at https://thecodingtrain/pixels. 