### PR TITLE
Enhanced Nested List Styles

### DIFF
--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -98,6 +98,22 @@ ul {
   }
 }
 
+ol > li > ol {
+  list-style-type: lower-alpha;
+
+  > li > ol {
+    list-style-type: lower-roman;
+  }
+}
+
+ul > li > ul {
+  list-style-type: circle;
+
+  > li > ul {
+    list-style-type: square;
+  }
+}
+
 figure {
   margin-top: 12pt;
   margin-bottom: 12pt;


### PR DESCRIPTION
#600 Use different styles for the second and third level of nested list, mirroring the types used in Notion.

Updated SCSS for Nested Lists:

```scss
ol > li > ol {
  list-style-type: lower-alpha;

  > li > ol {
    list-style-type: lower-roman;
  }
}

ul > li > ul {
  list-style-type: circle;

  > li > ul {
    list-style-type: square;
  }
}
```

## Preview

<img width="283" alt="image" src="https://github.com/nature-of-code/noc-book-2023/assets/6762203/0af6d582-fc18-43a8-9b91-98f6bb10838a">
