### PR TITLE
Update in-table code blocks' style

### DIFF
--- a/magicbook/stylesheets/components/table.scss
+++ b/magicbook/stylesheets/components/table.scss
@@ -46,6 +46,7 @@ table {
   // block level code in table
   pre {
     background: $color-gray-100;
-    padding: 4pt 2pt;
+    border-radius: $rounded-radius-sm;
+    padding: 8pt;
   }
 }

--- a/magicbook/stylesheets/index.scss
+++ b/magicbook/stylesheets/index.scss
@@ -27,6 +27,7 @@ $color-gray-200: #cccccc;
 $color-gray-500: #808080;
 $color-gray-800: #333333;
 $rounded-radius: 8pt;
+$rounded-radius-sm: 4pt;
 
 // Page styles
 @import 'page';


### PR DESCRIPTION
Implementation of #350 

Added the following updates

- slight rounded corner for the boxes
- additional padding inside the boxes around the margins

<img width="661" alt="image" src="https://github.com/nature-of-code/noc-book-2023/assets/6762203/cb8e21a1-1cde-4355-9cec-0f6ba4e1a014">
