### PR TITLE
Monospace code comment font size

### DIFF
--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -101,6 +101,7 @@
       }
 
       code {
+        font-size: 7pt;
         line-height: initial;
         display: initial;
         background-color: initial;


### PR DESCRIPTION
For whatever reason 7pt seems to look right? But I'm not sure what the "proper" size should be?

<img width="742" alt="Screen Shot 2024-01-06 at 10 39 16 PM" src="https://github.com/nature-of-code/noc-book-2023/assets/191758/e8ff8a6a-2994-43a0-b845-ea7bebec6a30">
