### PR TITLE
Fix bug when comment overflowed on mobile screen

### DIFF
--- a/src/styles/codesplit.css
+++ b/src/styles/codesplit.css
@@ -9,7 +9,7 @@
 }
 
 .pair.split {
-  @apply bg-gray-200 border-l-2 border-noc-400 py-2 my-1 flex flex-col-reverse lg:flex-row justify-between flex-wrap-reverse gap-y-2 gap-x-8;
+  @apply bg-gray-200 border-l-2 border-noc-400 py-2 my-1 flex flex-col-reverse lg:flex-row justify-between flex-wrap lg:flex-wrap-reverse gap-y-2 gap-x-8;
 }
 
 .pair code.hljs {
@@ -21,5 +21,5 @@
 }
 
 .comment > p {
-  @apply lg:w-[18em];
+  @apply max-w-[calc(100vw-5.5rem)] lg:w-[18em];
 }


### PR DESCRIPTION
add responsive `flex-wrap` value.
should fix #646 