### PR TITLE
Remove page number for whole chapter reference

### DIFF
--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -87,7 +87,8 @@ a {
   color: inherit;
 
   // Internal links
-  &:not([href^='http']):not([href$='#'])::after {
+  // for the ones include '#' but not at the end
+  &:not([href^='http'])[href*='#']:not([href$='#'])::after {
     content: ' (see page ' target-counter(attr(href), page) ')';
   }
 

--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -87,7 +87,7 @@ a {
   color: inherit;
 
   // Internal links
-  &:not([href^='http'])::after {
+  &:not([href^='http']):not([href$='#'])::after {
     content: ' (see page ' target-counter(attr(href), page) ')';
   }
 


### PR DESCRIPTION
Ignore whole chapter reference in the PDF build

```html
<!-- will append '(see page xxx)' -->
<a href="#example-12-bouncing-ball-with-vectors">Example 1.2</a>

<!-- won't -->
<a href="/force#">Chapter 2</a>
```

Implementing #673