### PR TITLE
URLs style

### DIFF
--- a/magicbook.json
+++ b/magicbook.json
@@ -10,6 +10,7 @@
     "magicbook/plugins/relative-link.js",
     "magicbook/plugins/screenshot.js",
     "magicbook/plugins/chapter-opening.js",
+    "magicbook/plugins/anchor.js",
     "magicbook/plugins/callout.js"
   ],
   "files": [

--- a/magicbook/plugins/anchor.js
+++ b/magicbook/plugins/anchor.js
@@ -13,8 +13,10 @@ Plugin.prototype = {
 
         file.$el('a').each(function () {
           const anchor = file.$el(this);
-          const href = anchor.attr('href');
+          let href = anchor.attr('href');
           if (/^http/.exec(href)) {
+            href = href.replace(/[._=&-]+/g, '<wbr>$&');
+            href = href.replace(/[:/#]+/g, '$&<wbr>');
             anchor.append(` (<span class="url">${href}</span>)`);
           }
         });

--- a/magicbook/plugins/anchor.js
+++ b/magicbook/plugins/anchor.js
@@ -1,0 +1,32 @@
+const through = require('through2');
+const cheerio = require('cheerio');
+
+const Plugin = function (registry) {
+  registry.after('markdown:convert', 'anchor:url', this.addExternalLink);
+};
+
+Plugin.prototype = {
+  addExternalLink: function (config, stream, extras, callback) {
+    stream = stream.pipe(
+      through.obj(function (file, _, cb) {
+        file.$el = file.$el || cheerio.load(file.contents.toString());
+
+        file.$el('a').each(function () {
+          const anchor = file.$el(this);
+          const href = anchor.attr('href');
+          if (/^http/.exec(href)) {
+            anchor.append(` (<span class="url">${href}</span>)`);
+          }
+        });
+
+        file.contents = Buffer.from(file.$el.html());
+
+        cb(null, file);
+      }),
+    );
+
+    callback(null, config, stream, extras);
+  },
+};
+
+module.exports = Plugin;

--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -92,9 +92,8 @@ a {
     content: ' (see page ' target-counter(attr(href), page) ')';
   }
 
-  // External links
-  &[href^='http']::after {
-    content: ' (' attr(href) ')';
+  span.url {
+    font-style: italic;
   }
 }
 


### PR DESCRIPTION
Implementation of #664 

- Set URLs style in italic (not the parentheses)
- Add line-break rules
	> should break BEFORE periods, underscores, equal signs, ampersands, and hyphens but AFTER colons, slashes and hash marks.

<img width="1100" alt="image" src="https://github.com/nature-of-code/noc-book-2023/assets/6762203/65fb33ff-2717-45a2-8f8f-7d3ea534f01c">