### PR TITLE
Update chapter opening style

### DIFF
--- a/magicbook/stylesheets/components/chapter-opening.scss
+++ b/magicbook/stylesheets/components/chapter-opening.scss
@@ -44,6 +44,12 @@
           font-style: normal;
         }
       }
+
+      .chapter-opening-quote-long {
+        p{
+          font-size:7pt;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Added a callout box in Notion for long quotes and make the font size 1 pt smaller in codesplit.scss.

The result looks like this, which fix the word 'born' falling into the next line. See issue #697.

<img width="780" alt="Screenshot 2024-02-10 at 21 54 09" src="https://github.com/nature-of-code/noc-book-2023/assets/90000947/ad3632c8-ab8b-416c-9fd9-22490f3f8f74">
