### PR TITLE
Change code comment style to bold

### DIFF
--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -100,6 +100,7 @@
 
       code {
         font-size: 7pt;
+        font-weight: 700;
         line-height: initial;
         display: initial;
         background-color: initial;


### PR DESCRIPTION
Highlight `code` in comment as bold text. Implementation of #670 

<img width="817" alt="image" src="https://github.com/nature-of-code/noc-book-2023/assets/6762203/9d5274bc-2fc2-49f7-bf98-2bdd4d493a77">
