### PR TITLE
Remove trailing slash from URLs

### DIFF
--- a/magicbook/plugins/anchor.js
+++ b/magicbook/plugins/anchor.js
@@ -14,6 +14,11 @@ Plugin.prototype = {
         file.$el('a').each(function () {
           const anchor = file.$el(this);
           let href = anchor.attr('href');
+
+          // remove trailing slash
+          href = href.replace(/\/$/, '');
+
+          // add line break opportunities
           if (/^http/.exec(href)) {
             href = href.replace(/[._=&-]+/g, '<wbr>$&');
             href = href.replace(/[:/#]+/g, '$&<wbr>');


### PR DESCRIPTION
Added a step in the PDF build process to remove all the trailing slash of URLs.
Implementation of #683