### PR TITLE
Chapter opening image title fix

### DIFF
--- a/magicbook/stylesheets/components/chapter-opening.scss
+++ b/magicbook/stylesheets/components/chapter-opening.scss
@@ -57,6 +57,7 @@
     h3 {
       margin: 12pt 5mm 6pt;
       font-size: 7pt;
+      color: #666666;
     }
 
     p {


### PR DESCRIPTION
Relate issue #674 
update the image title into 60%K!

<img width="696" alt="Screenshot 2024-02-12 at 09 26 47" src="https://github.com/nature-of-code/noc-book-2023/assets/90000947/07202576-faae-4d94-9264-d396d6704949">