### PR TITLE
Add class to manually control break inside blocks

### DIFF
--- a/magicbook/stylesheets/components/callout.scss
+++ b/magicbook/stylesheets/components/callout.scss
@@ -20,6 +20,14 @@ div[data-type='project'] {
   }
 }
 
+.avoid-break {
+  page-break-inside: avoid;
+}
+
+.allow-break > div {
+  page-break-inside: auto;
+}
+
 span.highlight {
   display: block;
   padding-left: 12pt;


### PR DESCRIPTION
Add `allow-break` and `avoid-break` to manually adjust break across pages behavior

![image](https://github.com/nature-of-code/noc-book-2023/assets/6762203/a98c4927-2c63-4af0-866d-d3209205c9c5)

<img width="760" alt="image" src="https://github.com/nature-of-code/noc-book-2023/assets/6762203/f7516a01-22f9-4527-9eec-52a6faefc7a3">

#698 