### PR TITLE
[Fix bug] scissors break before or after page

### DIFF
--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -5,15 +5,15 @@
     border-top-right-radius: 0;
     border-top-left-radius: 0;
     border-top: 1px dashed $color-gray-200;
-  }
 
-  &::before {
-    position: absolute;
-    top: -5.75pt;
-    left: -6pt;
-    content: url('icons/scissors.png');
-    width: 10pt;
-    height: 10pt;
+    .pair:first-child::before {
+      position: absolute;
+      top: -5.75pt;
+      left: -6pt;
+      content: url('icons/scissors.png');
+      width: 10pt;
+      height: 10pt;
+    }
   }
 }
 
@@ -24,15 +24,15 @@
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
     border-bottom: 1px dashed $color-gray-200;
-  }
 
-  &::after {
-    position: absolute;
-    bottom: -5pt;
-    left: -6pt;
-    content: url('icons/scissors.png');
-    width: 10pt;
-    height: 10pt;
+    .pair:last-child::after {
+      position: absolute;
+      bottom: -5pt;
+      left: -6pt;
+      content: url('icons/scissors.png');
+      width: 10pt;
+      height: 10pt;
+    }
   }
 }
 


### PR DESCRIPTION
Now scissors are added to the first/last child pair instead of the whole codesplit. This should fix #762 

<img width="1318" alt="image" src="https://github.com/nature-of-code/noc-book-2023/assets/6762203/3f70fc61-71d9-417f-ad73-b56e267daaf9">
