### PR TITLE
Improve comment display and marks handling

### DIFF
--- a/magicbook/plugins/codesplit.js
+++ b/magicbook/plugins/codesplit.js
@@ -71,15 +71,24 @@ Plugin.prototype = {
         const regex = /\{(.+)\}/;
         const match = regex.exec(line);
         if (match) {
-          const values = match[1].trim().split(' ');
-          values.forEach((value) => {
-            if (value.charAt(0) === '#') pair.id = value.substring(1);
-            if (value.charAt(0) === '.') {
-              pair.className.push(value.substring(1));
-            }
-            if (value.charAt(0) === '!')
-              pair.maxLines = parseInt(value.substring(1));
-          });
+          // match !.#
+          const marks = match[1].match(/([!#.])([^!#.\s]+)/g);
+
+          if (marks) {
+            marks.forEach((mark) => {
+              switch (mark.charAt(0)) {
+                case '#':
+                  pair.id = mark.substring(1);
+                  break;
+                case '.':
+                  pair.className.push(mark.substring(1));
+                  break;
+                case '!':
+                  pair.maxLines = parseInt(mark.substring(1));
+                  break;
+              }
+            });
+          }
           line = line.replace(regex, '');
         }
 
@@ -94,7 +103,9 @@ Plugin.prototype = {
 
     pairs.forEach((pair) => {
       const code = pair.code.join('\n') + '\n';
-      const comments = pair.comment.map((str) => str.replace('//', '').trim());
+      const comments = pair.comment
+        .map((str) => str.replace('//', '').trim())
+        .filter((str) => !!str);
       const className = pair.className.concat('pair');
 
       // highlight the pair that has comment

--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -85,6 +85,10 @@
       border-top: 1pt solid $color-gray-100;
     }
 
+    &.highlight + .pair.continue {
+      border-top: initial;
+    }
+
     .comment {
       page-break-inside: avoid;
       flex-grow: 1;

--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -24,7 +24,6 @@
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
     border-bottom: 1px dashed $color-gray-200 !important;
-  }
 
     .pair:last-child::after {
       position: absolute;


### PR DESCRIPTION
Updates on the codesplits' comment

1. match 3 types of marks with regex. `{!2.className#id}`
2. remove blank comment paragraph.
3. add `.pair.continue` to remove top border to achieve better rendering of #694 