### PR TITLE
Only keep highlight pairs from breaking

### DIFF
--- a/magicbook/stylesheets/components/codesplit.scss
+++ b/magicbook/stylesheets/components/codesplit.scss
@@ -52,7 +52,6 @@
     display: flex;
     flex-wrap: wrap-reverse;
     justify-content: space-between;
-    break-inside: avoid;
     padding: 0 5mm;
 
     &:first-child {
@@ -78,6 +77,7 @@
 
     &.highlight {
       background: $color-gray-200;
+      break-inside: avoid;
 
       // add a margin between adjacent highlight pairs
       + .pair.highlight {


### PR DESCRIPTION
Quick fix #775

Only apply the `break-inside: avoid;` on highlight pairs (one with comment)