### PR TITLE
[Fix] Roman numerals for page references in front matter

### DIFF
--- a/magicbook.json
+++ b/magicbook.json
@@ -32,6 +32,11 @@
       "magicbook/stylesheets/index.scss"
     ]
   },
+  "javascripts": {
+    "files": [
+      "magicbook/scripts/*.js"
+    ]
+  },
   "fonts": {
     "files": "magicbook/fonts/**/*.*",
     "destination": "assets/fonts/"

--- a/magicbook/scripts/format-number.js
+++ b/magicbook/scripts/format-number.js
@@ -1,0 +1,5 @@
+function formatNumber(isDecimal, decimalNumber, romanNumber) {
+  return isDecimal === '1' ? decimalNumber : romanNumber;
+}
+
+Prince.addScriptFunc('format-number', formatNumber);

--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -91,7 +91,14 @@ a {
   // Internal links
   // for the ones include '#' but not at the end
   &:not([href^='http'])[href*='#']:not([href$='#'])::after {
-    content: ' (see page ' target-counter(attr(href), page) ')';
+    content: ' (see page '
+      prince-script(
+        format-number,
+        target-counter(attr(href), is-decimal),
+        target-counter(attr(href), page),
+        target-counter(attr(href), page, lower-roman)
+      )
+      ')';
   }
 
   span.url {

--- a/magicbook/stylesheets/page.scss
+++ b/magicbook/stylesheets/page.scss
@@ -90,7 +90,7 @@ section[data-type='chapter'] {
   prince-page-group: start;
 
   &[data-chapter-number='0'] {
-    counter-reset: page 1;
+    counter-reset: page 1 is-decimal 1;
   }
 
   @include section-footer(counter(page));
@@ -164,7 +164,7 @@ section[data-type='page']:has(#introduction) {
 section[data-type='page']:has(#acknowledgments) {
   page: frontmatter;
   prince-page-group: start;
-  counter-reset: page 17;
+  counter-reset: page 17 is-decimal 0;
 
   @include section-footer(counter(page, lower-roman));
 }


### PR DESCRIPTION
Fix #782

This fix is essentially a hack. A custom counter named `is-decimal` is added to track the page number style. So they can be select correctly by a custom script function applying a conditional operation.

```css
prince-script(
  format-number,
  target-counter(attr(href), is-decimal),
  target-counter(attr(href), page),
  target-counter(attr(href), page, lower-roman)
)
```

```js
function formatNumber(isDecimal, decimalNumber, romanNumber) {
  return isDecimal === '1' ? decimalNumber : romanNumber;
}

Prince.addScriptFunc('format-number', formatNumber);
```