### PR TITLE
Change cross reference format

### DIFF
--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -91,14 +91,13 @@ a {
   // Internal links
   // for the ones include '#' but not at the end
   &:not([href^='http'])[href*='#']:not([href$='#'])::after {
-    content: ' (see page '
+    content: ' on page '
       prince-script(
         format-number,
         target-counter(attr(href), is-decimal),
         target-counter(attr(href), page),
         target-counter(attr(href), page, lower-roman)
-      )
-      ')';
+      );
   }
 
   span.url {


### PR DESCRIPTION
Implementation of #787

Change page cross reference's format from `(see page xx)` to `on page xx`.