### PR TITLE
Only adding page number after `link.page-reference`

### DIFF
--- a/magicbook/stylesheets/components/typography.scss
+++ b/magicbook/stylesheets/components/typography.scss
@@ -90,7 +90,7 @@ a {
 
   // Internal links
   // for the ones include '#' but not at the end
-  &:not([href^='http'])[href*='#']:not([href$='#'])::after {
+  &.page-reference:not([href^='http'])[href*='#']:not([href$='#'])::after {
     content: ' on page '
       prince-script(
         format-number,


### PR DESCRIPTION
With the update in `fetch-notion`, this will only add page number reference to anchor tag referencing blocks instead of pages.