### PR TITLE
Update page number and footer style

### DIFF
--- a/magicbook/stylesheets/page.scss
+++ b/magicbook/stylesheets/page.scss
@@ -14,7 +14,9 @@
 @mixin footer {
   font-family: $font-sans;
   font-weight: $font-book;
-  font-size: 9pt;
+  font-size: 6pt;
+  display: flex;
+  align-items: center;
   vertical-align: top;
   padding-top: 2em;
 }
@@ -26,6 +28,7 @@
 
     &::before {
       margin-right: 12pt;
+      font-size: 7pt;
       font-weight: $font-bold;
       content: $content;
     }
@@ -34,10 +37,11 @@
   div.running-footer-right {
     position: running(footer-right);
     @include footer;
-    text-align: right;
+    justify-content: flex-end;
 
     &::after {
       margin-left: 12pt;
+      font-size: 7pt;
       font-weight: $font-bold;
       content: $content;
     }


### PR DESCRIPTION
The footer style is updated according to the feedback #883

> Can the page numbers be changed to 7pt font and running footer text to 6pt font? The footers should not be larger than the main text.