### PR TITLE
[Fix] Check if maxLines is `undefined`

### DIFF
--- a/magicbook/plugins/codesplit.js
+++ b/magicbook/plugins/codesplit.js
@@ -51,7 +51,7 @@ Plugin.prototype = {
         (this.isComment(line) && pair.code.length > 0) ||
         (!pair.maxLines && currentIndent < pair.indent) ||
         (!pair.maxLines && line === '' && pair.comment.length > 0) ||
-        (!!pair.maxLines && pair.code.length >= pair.maxLines)
+        (pair.maxLines !== undefined && pair.code.length >= pair.maxLines)
       ) {
         if (pair.code.length > 0 || pair.comment.length > 0) {
           pairs.push(pair);


### PR DESCRIPTION
Switch the if condition from:

```
!!pair.maxLines
```

to:

```
pair.maxLines !== undefined
```

since `0` could be a valid number and the first one won't work