### PR TITLE
Modified code snippets' theme color palette to achieve better contrast

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,5 @@
 import './src/styles/global.css';
 // highlight
-import 'highlight.js/styles/github.css';
+import './src/styles/hljs-theme-github.css';
 // Katex
 import 'katex/dist/katex.min.css';

--- a/src/styles/hljs-theme-github.css
+++ b/src/styles/hljs-theme-github.css
@@ -1,0 +1,119 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+
+  Modified to increase contrast
+*/
+.hljs {
+  color: #24292e;
+  background: #ffffff;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #c32837;
+}
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #6f42c1;
+}
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #005cc5;
+}
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #032f62;
+}
+.hljs-built_in,
+.hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #aa4908;
+}
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #606771;
+}
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #1e7631;
+}
+.hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #24292e;
+}
+.hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #005cc5;
+  font-weight: bold;
+}
+.hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #735c0f;
+}
+.hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #24292e;
+  font-style: italic;
+}
+.hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #24292e;
+  font-weight: bold;
+}
+.hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #22863a;
+  background-color: #f0fff4;
+}
+.hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #b31d28;
+  background-color: #ffeef0;
+}
+.hljs-char.escape_,
+.hljs-link,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+}


### PR DESCRIPTION
This pull request modifies the colors used in our code snippet highlighting to ensure a minimum color contrast ratio of 4.5:1 for better accessibility. The specific changes are as follows:

### 1. Keyword Colors:

```css
.hljs-doctag,
.hljs-keyword,
.hljs-meta .hljs-keyword,
.hljs-template-tag,
.hljs-template-variable,
.hljs-type,
.hljs-variable.language_ {
  /* prettylights-syntax-keyword */
  /* color: #d73a49; */
  color: #c32837;
}
```

### 2. Built-in and Symbol Colors:

```css
.hljs-built_in,
.hljs-symbol {
  /* prettylights-syntax-variable */
  /* color: #e36209; */
  color: #aa4908;
}
```

### 3. Comment and Formula Colors:

```css
.hljs-comment,
.hljs-code,
.hljs-formula {
  /* prettylights-syntax-comment */
  /* color: #6a737d; */
  color: #606771;
}
```

### 4. Name, Quote, and Selector Tag Colors:

```css
.hljs-name,
.hljs-quote,
.hljs-selector-tag,
.hljs-selector-pseudo {
  /* prettylights-syntax-entity-tag */
  /* color: #22863a; */
  color: #1e7631;
}
```

These changes have been tested using the WAVE Evaluation tools.

It will resolve #951 