### PR TITLE
Bump actions version

### DIFF
--- a/.github/workflows/notion-git.yml
+++ b/.github/workflows/notion-git.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Fetch Notion content
         uses: nature-of-code/fetch-notion@main
@@ -16,7 +16,7 @@ jobs:
           notion-database-id: ${{ secrets.NOTION_DATABASE_ID }}
       
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           commit-message: Notion - Update docs
           signoff: false


### PR DESCRIPTION
This PR updates the version of two actions we run in our workflow:

- actions/checkout: v3 -> v4
- peter-evans/create-pull-request: v4 -> v6

Resolves #996