### PR TITLE
Fix `<main>` overflow issue at specific screen widths

### DIFF
--- a/src/layouts/SideNavLayout.js
+++ b/src/layouts/SideNavLayout.js
@@ -13,7 +13,9 @@ export default function SideNavLayout(props) {
           <SideNav activeChapter={title && title.split('. ')[0]} toc={toc} />
         </aside>
 
-        <main className="prose mx-auto max-w-[50em] pb-8">{children}</main>
+        <main className="prose mx-auto min-w-0 max-w-[50em] pb-8">
+          {children}
+        </main>
       </div>
     </BaseLayout>
   );


### PR DESCRIPTION
Solution: Add `min-width: 0;` to the `<main>` element to allow it to shrink when there isn't enough space.

## Example

<img width="1205" alt="image" src="https://github.com/user-attachments/assets/40f5da42-9e06-4069-9759-0cce57e065d4">