### PR TITLE
Fix: overflowing images in callout

### DIFF
--- a/src/components/Codesplit.js
+++ b/src/components/Codesplit.js
@@ -47,7 +47,7 @@ const Codesplit = (props) => {
 
   return (
     <div
-      className={`pt-0 ${props.className} ${isAnswerVisible ? 'is-answer-visible' : ''}`}
+      className={`overflow-visible pt-0 ${props.className} ${isAnswerVisible ? 'is-answer-visible' : ''}`}
     >
       <div className="flex items-start justify-between">
         <LanguageNameBadge language={props['data-code-language']} />

--- a/src/styles/callout.css
+++ b/src/styles/callout.css
@@ -1,5 +1,5 @@
 .callout {
-  @apply clear-both my-4 rounded bg-gray-100 py-4;
+  @apply clear-both my-4 overflow-y-auto rounded bg-gray-100 py-4;
 }
 
 .callout:not(.codesplit) {

--- a/src/styles/codesplit.css
+++ b/src/styles/codesplit.css
@@ -1,9 +1,4 @@
 /** codesplit div styles */
-
-.codesplit {
-  @apply my-4 rounded bg-gray-100 py-4;
-}
-
 .snip-above > .codesplit {
   @apply relative rounded-t-none border-t border-dashed border-gray-400;
 }


### PR DESCRIPTION
Fix #1024

*This bug has occurred #299, and while it was initially addressed in PR #432, the fix was later reverted due to a conflict with the newly introduced codesplit block. However, both issues have now been resolved in this PR.*