### PR TITLE
Update Codesplit.js for HTML tag background color

### DIFF
--- a/src/components/Codesplit.js
+++ b/src/components/Codesplit.js
@@ -13,7 +13,7 @@ const LanguageNameBadge = ({ language }) => {
   };
 
   return (
-    <div className="ml-4 rounded-b-md bg-noc-400 px-2 py-0.5 text-xs text-white">
+    <div className="ml-4 rounded-b-md bg-gray-400 px-2 py-0.5 text-xs text-white">
       {LANGUAGE_NAME_ALIAS[language] || language}
     </div>
   );


### PR DESCRIPTION
Relate to issue #1016 
Changed the color for HTML tag to dark gray.

<img width="843" alt="Screenshot 2024-10-15 at 14 40 50" src="https://github.com/user-attachments/assets/dc539760-5d80-468c-9731-d9262f71d946">
