### PR TITLE
Feat: replace <br> with space in the website build

### DIFF
--- a/gatsby/lib/br-space.mjs
+++ b/gatsby/lib/br-space.mjs
@@ -1,0 +1,10 @@
+import { visit } from 'unist-util-visit';
+
+export default function rehypeReplaceBrWithSpace() {
+  return (tree) => {
+    visit(tree, { tagName: 'br' }, (node, index, parent) => {
+      // Replace the <br> with a space to avoid line breaks
+      parent.children.splice(index, 1, { type: 'text', value: ' ' });
+    });
+  };
+}

--- a/gatsby/lib/parse-content.mjs
+++ b/gatsby/lib/parse-content.mjs
@@ -12,6 +12,7 @@ import { toString } from 'hast-util-to-string';
 import { rehypeCodesplit } from './codesplit.mjs';
 import { preserveCustomSpans, restoreCustomSpans } from './blank-span.mjs';
 import { rehypeVideoLink } from './video-link.mjs';
+import rehypeReplaceBrWithSpace from './br-space.mjs';
 
 export function parseContent(html) {
   const replaceMedia = () => (tree) => {
@@ -191,6 +192,7 @@ export function parseContent(html) {
     .use(replaceMedia)
     .use(rehypeVideoLink)
     .use(externalLinkInNewTab)
+    .use(rehypeReplaceBrWithSpace)
     .use(rehypeCodesplit)
     .use(preserveCustomSpans)
     .use(rehypeHighlight)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,9 +71,4 @@
   h3 {
     @apply clear-both scroll-mt-24;
   }
-
-  br,
-  br:after {
-    content: ' ';
-  }
 }


### PR DESCRIPTION
References: Issue #1020, #900
The pure CSS solution implemented earlier did not work as expected in Safari.

This PR introduces a JS solution by replacing `<br>` tags with spaces, ensuring they do not appear on the website.