### PR TITLE
Fix: decoration in code snippet

### DIFF
--- a/gatsby/lib/codesplit.mjs
+++ b/gatsby/lib/codesplit.mjs
@@ -131,11 +131,15 @@ export const rehypeCodesplit = () => (tree) => {
         // highlight the pair that has comment
         if (pair.comment.length > 0) className.push('split');
 
-        if (containsTag(code, 's')) className.push('code-strikethrough');
-        if (containsTag(code, 'strong')) className.push('code-bold');
+        // not highlight when it contains <s> tag for line-through decoration
+        const codeClassName = [
+          'code',
+          containsTag(code, 's') ? 'code-strikethrough' : `language-${lang}`,
+        ];
+        if (containsTag(code, 'strong')) codeClassName.push('code-bold');
 
         return h('div', { className }, [
-          h('pre', [h('code', { class: ['code', `language-${lang}`] }, code)]),
+          h('pre', [h('code', { class: codeClassName }, code)]),
           h(
             'div',
             { class: ['comment'] },

--- a/gatsby/lib/codesplit.mjs
+++ b/gatsby/lib/codesplit.mjs
@@ -17,6 +17,23 @@ const countIndent = (str) => {
   return match ? match[0].length : 0;
 };
 
+const containsTag = (node, targetTagName) => {
+  if (node.tagName === targetTagName) {
+    return true;
+  }
+
+  // If the node has children, check them recursively
+  if (node.children && Array.isArray(node.children)) {
+    for (const child of node.children) {
+      if (containsTag(child, targetTagName)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
 export const rehypeCodesplit = () => (tree) => {
   visit(tree, { tagName: 'pre' }, (node) => {
     if (
@@ -113,6 +130,9 @@ export const rehypeCodesplit = () => (tree) => {
 
         // highlight the pair that has comment
         if (pair.comment.length > 0) className.push('split');
+
+        if (containsTag(code, 's')) className.push('code-strikethrough');
+        if (containsTag(code, 'strong')) className.push('code-bold');
 
         return h('div', { className }, [
           h('pre', [h('code', { class: ['code', `language-${lang}`] }, code)]),

--- a/src/styles/codesplit.css
+++ b/src/styles/codesplit.css
@@ -19,6 +19,14 @@
   @apply w-full overflow-x-auto px-5;
 }
 
+.pair.code-strikethrough > pre {
+  @apply line-through;
+}
+
+.pair.code-bold > pre {
+  @apply font-bold;
+}
+
 .pair.split {
   @apply my-1 flex flex-col-reverse flex-wrap justify-between gap-x-8 gap-y-2 border-l-2 border-noc-200 bg-gray-200 py-2 lg:flex-row lg:flex-wrap-reverse;
 }

--- a/src/styles/codesplit.css
+++ b/src/styles/codesplit.css
@@ -19,11 +19,11 @@
   @apply w-full overflow-x-auto px-5;
 }
 
-.pair.code-strikethrough > pre {
-  @apply line-through;
+.pair > pre > code.code-strikethrough {
+  @apply block bg-transparent p-0 text-sm leading-5;
 }
 
-.pair.code-bold > pre {
+.pair > pre > code.code-bold {
   @apply font-bold;
 }
 


### PR DESCRIPTION
This PR fix issue #983 where `<s/>` (strikethrough) and `<strong/>` (bold) elements were being removed when applying syntax highlighting on code snippets using `highlight.js`. The changes bring back these decorations with the following details:

- **Bold Annotation**: If a bold tag is found, the whole line of code will be bolded.
- ~~Strikethrough Annotation~~: Any line that contains a strikethrough will lose its highlight. This is usually fine since strikethrough is often used for "incorrect" solutions or deprecated code examples.
