### PR TITLE
Update buying links

### DIFF
--- a/src/components/PurchaseButtons.js
+++ b/src/components/PurchaseButtons.js
@@ -32,7 +32,7 @@ export const PurchaseDirectButton = ({ id, className }) => {
     <div className={`relative h-[36px] w-[120px] ${className}`}>
       {/* Loading Animation */}
       <button
-        className={`${loading ? 'flex' : 'hidden'} absolute inset-0 cursor-not-allowed items-center justify-center rounded-xl bg-noc-400 text-white `}
+        className={`${loading ? 'flex' : 'hidden'} absolute inset-0 cursor-not-allowed items-center justify-center rounded-xl bg-noc-400 text-white`}
       >
         <LuLoader2 className="h-5 w-5 animate-spin" />
       </button>
@@ -46,14 +46,14 @@ const PurchaseButtons = ({ aligned = 'right', className }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
 
-  //close menu when click outside
+  // Close menu when click outside
   const handleClickOutside = (event) => {
     if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
       setIsOpen(false);
     }
   };
 
-  //close menu when the 'esc' key is pressed
+  // Close menu when the 'esc' key is pressed
   const handleKeyDown = (event) => {
     if (event.key === 'Escape') {
       setIsOpen(false);

--- a/src/components/PurchaseButtons.js
+++ b/src/components/PurchaseButtons.js
@@ -21,8 +21,8 @@ const links = [
   },
   {
     href: 'https://github.com/nature-of-code/buyers-guide',
-    label: 'Global Retailers'
-  }
+    label: 'Global Retailers',
+  },
 ];
 
 export const PurchaseDirectButton = ({ id, className }) => {
@@ -66,11 +66,10 @@ const PurchaseButtons = ({ aligned = 'right', className }) => {
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleKeyDown);
-    }
+    };
   }, []);
 
   return (
-
     <div className={`not-prose flex items-center gap-4 ${className}`}>
       {/* Shopify Buy Button */}
       <PurchaseDirectButton />
@@ -84,19 +83,25 @@ const PurchaseButtons = ({ aligned = 'right', className }) => {
         >
           Other Options
           <FiChevronDown
-            className={`-mr-1 ml-1 h-5 w-5 transfrom ${isOpen ? 'rotate-180' : 'rotate-0'}`} />
+            className={`transfrom -mr-1 ml-1 h-5 w-5 ${isOpen ? 'rotate-180' : 'rotate-0'}`}
+          />
         </button>
         {isOpen && (
-          <ul className={`absolute ${aligned === 'right' ? 'right-0' : 'left-0'} z-50 mt-1 w-40 divide-y rounded-xl border border-noc-200 bg-white`}>
+          <ul
+            className={`absolute ${aligned === 'right' ? 'right-0' : 'left-0'} z-50 mt-1 w-40 divide-y rounded-xl border border-noc-200 bg-white`}
+          >
             {links.map((link) => (
               <li key={link.href} className="border-noc-200">
-                <a href={link.href} className="block px-4 py-2 text-sm text-gray-800 hover:underline">
+                <a
+                  href={link.href}
+                  className="block px-4 py-2 text-sm text-gray-800 hover:underline"
+                >
                   {link.label}
                 </a>
               </li>
             ))}
-          </ul>)}
-
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/src/components/PurchaseButtons.js
+++ b/src/components/PurchaseButtons.js
@@ -19,6 +19,10 @@ const links = [
     href: 'https://www.barnesandnoble.com/w/the-nature-of-code-daniel-shiffman/1114086024',
     label: 'Barnes & Noble',
   },
+  {
+    href: 'https://github.com/nature-of-code/buyers-guide',
+    label: 'Global Retailers'
+  }
 ];
 
 export const PurchaseDirectButton = ({ id, className }) => {
@@ -28,7 +32,7 @@ export const PurchaseDirectButton = ({ id, className }) => {
     <div className={`relative h-[36px] w-[120px] ${className}`}>
       {/* Loading Animation */}
       <button
-        className={`${loading ? 'flex' : 'hidden'} absolute inset-0 cursor-not-allowed items-center justify-center rounded-xl bg-noc-400 text-white uppercase`}
+        className={`${loading ? 'flex' : 'hidden'} absolute inset-0 cursor-not-allowed items-center justify-center rounded-xl bg-noc-400 text-white `}
       >
         <LuLoader2 className="h-5 w-5 animate-spin" />
       </button>
@@ -39,17 +43,60 @@ export const PurchaseDirectButton = ({ id, className }) => {
 };
 
 const PurchaseButtons = ({ aligned = 'right', className }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef(null);
+
+  //close menu when click outside
+  const handleClickOutside = (event) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+      setIsOpen(false);
+    }
+  };
+
+  //close menu when the 'esc' key is pressed
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      setIsOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, []);
+
   return (
+
     <div className={`not-prose flex items-center gap-4 ${className}`}>
       {/* Shopify Buy Button */}
       <PurchaseDirectButton />
 
-      <div className="relative">
-        <a href="https://github.com/nature-of-code/buyers-guide/blob/main/README.md"><button
-          className="flex items-center rounded-xl border border-noc-200 px-4 py-[7px] text-sm text-noc-500 uppercase"
-        > Buyers Guide
+      <div className="relative" ref={dropdownRef}>
+        <button
+          aria-haspopup="true"
+          aria-expanded={isOpen}
+          className="flex items-center rounded-xl border border-noc-200 px-4 py-[7px] text-sm text-noc-500"
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          Other Options
+          <FiChevronDown
+            className={`-mr-1 ml-1 h-5 w-5 transfrom ${isOpen ? 'rotate-180' : 'rotate-0'}`} />
+        </button>
+        {isOpen && (
+          <ul className={`absolute ${aligned === 'right' ? 'right-0' : 'left-0'} z-50 mt-1 w-40 divide-y rounded-xl border border-noc-200 bg-white`}>
+            {links.map((link) => (
+              <li key={link.href} className="border-noc-200">
+                <a href={link.href} className="block px-4 py-2 text-sm text-gray-800 hover:underline">
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>)}
 
-        </button></a>
       </div>
     </div>
   );

--- a/src/components/PurchaseButtons.js
+++ b/src/components/PurchaseButtons.js
@@ -28,7 +28,7 @@ export const PurchaseDirectButton = ({ id, className }) => {
     <div className={`relative h-[36px] w-[120px] ${className}`}>
       {/* Loading Animation */}
       <button
-        className={`${loading ? 'flex' : 'hidden'} absolute inset-0 cursor-not-allowed items-center justify-center rounded-xl bg-noc-400 text-white`}
+        className={`${loading ? 'flex' : 'hidden'} absolute inset-0 cursor-not-allowed items-center justify-center rounded-xl bg-noc-400 text-white uppercase`}
       >
         <LuLoader2 className="h-5 w-5 animate-spin" />
       </button>
@@ -39,66 +39,17 @@ export const PurchaseDirectButton = ({ id, className }) => {
 };
 
 const PurchaseButtons = ({ aligned = 'right', className }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef(null);
-
-  // close menu when click outside
-  const handleClickOutside = (event) => {
-    if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-      setIsOpen(false);
-    }
-  };
-
-  // close menu when the 'esc' key is pressed
-  const handleKeyDown = (event) => {
-    if (event.key === 'Escape') {
-      setIsOpen(false);
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleKeyDown);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, []);
-
   return (
     <div className={`not-prose flex items-center gap-4 ${className}`}>
       {/* Shopify Buy Button */}
       <PurchaseDirectButton />
 
-      <div className="relative" ref={dropdownRef}>
-        <button
-          aria-haspopup="true"
-          aria-expanded={isOpen}
-          className="flex items-center rounded-xl border border-noc-200 px-4 py-[7px] text-sm text-noc-500"
-          onClick={() => setIsOpen(!isOpen)}
-        >
-          Other Options
-          <FiChevronDown
-            className={`-mr-1 ml-1 h-5 w-5 transform ${isOpen ? 'rotate-180' : 'rotate-0'}`}
-          />
-        </button>
+      <div className="relative">
+        <a href="https://github.com/nature-of-code/buyers-guide/blob/main/README.md"><button
+          className="flex items-center rounded-xl border border-noc-200 px-4 py-[7px] text-sm text-noc-500 uppercase"
+        > Buyers Guide
 
-        {isOpen && (
-          <ul
-            className={`absolute ${aligned === 'right' ? 'right-0' : 'left-0'} z-50 mt-1 w-40 divide-y rounded-xl border border-noc-200 bg-white`}
-          >
-            {links.map((link) => (
-              <li key={link.href} className="border-noc-200">
-                <a
-                  href={link.href}
-                  className="block px-4 py-2 text-sm text-gray-800 hover:underline"
-                >
-                  {link.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        )}
+        </button></a>
       </div>
     </div>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -19,6 +19,10 @@ const links = [
     href: 'https://www.barnesandnoble.com/w/the-nature-of-code-daniel-shiffman/1114086024',
     label: 'Barnes & Noble',
   },
+  {
+    href: 'https://github.com/nature-of-code/buyers-guide',
+    label: 'Global Retailers'
+  }
 ];
 
 export default function IndexPage() {
@@ -70,7 +74,7 @@ export default function IndexPage() {
       <StaticImage
         className="float-right"
         src="../images/bookmark-pink-bg.png"
-        width={200}
+        width={150}
         alt="a hand holding a bookmark and a sticker"
       />
       <div className="my-6">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -75,15 +75,28 @@ export default function IndexPage() {
       />
       <div className="my-6">
         <b>Buying options</b>
-        <PurchaseDirectButton className="mt-4" />
-        <p className="text-sm">*includes exclusive bookmark and sticker!</p>
-        {links.map((link) => (
-          <a href={link.href} className="px-1">
-            <button key={link.href} className="mt-4 items-center rounded-xl border border-noc-200 px-3 py-[7px] text-sm text-noc-500 ">
-              {link.label}
-            </button>
-          </a>
-        ))}
+
+        {/* Order Direct */}
+        <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <PurchaseDirectButton />
+          <p className="my-0 text-sm">
+            *includes exclusive bookmark and sticker!
+          </p>
+        </div>
+
+        {/* Other Options */}
+        <div className="mt-4 flex flex-wrap gap-2">
+          {links.map((link) => (
+            <a href={link.href} key={link.href}>
+              <button
+                key={link.href}
+                className="rounded-xl border border-noc-200 px-3 py-[7px] text-sm text-noc-500"
+              >
+                {link.label}
+              </button>
+            </a>
+          ))}
+        </div>
       </div>
     </SideNavLayout>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,8 +21,8 @@ const links = [
   },
   {
     href: 'https://github.com/nature-of-code/buyers-guide',
-    label: 'Global Retailers'
-  }
+    label: 'Global Retailers',
+  },
 ];
 
 export default function IndexPage() {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -74,24 +74,16 @@ export default function IndexPage() {
         alt="a hand holding a bookmark and a sticker"
       />
       <div className="my-6">
+        <b>Buying options</b>
         <PurchaseDirectButton className="mt-4" />
         <p className="text-sm">*includes exclusive bookmark and sticker!</p>
-      </div>
-
-      <div className="my-6">
-        <b>Also available at: </b>
-        <ul className="left-0 my-2 px-0">
-          {links.map((link) => (
-            <li key={link.href} className=" my-0 list-inside px-0">
-              <a
-                href={link.href}
-                className=" text-sm text-gray-800 hover:underline"
-              >
-                {link.label}
-              </a>
-            </li>
-          ))}
-        </ul>
+        {links.map((link) => (
+          <a href={link.href} className="px-1">
+            <button key={link.href} className="mt-4 items-center rounded-xl border border-noc-200 px-3 py-[7px] text-sm text-noc-500 ">
+              {link.label}
+            </button>
+          </a>
+        ))}
       </div>
     </SideNavLayout>
   );


### PR DESCRIPTION
Relate to issue #1008 

On the top nav bar, I switched the "buying options" dropdown menu into "buyers guide" button.
Also on the landing page, I updated the buying options and the buttons layout.

( a preview without the "order direct" shopify button)
<img width="1260" alt="Screenshot 2024-11-03 at 22 19 49" src="https://github.com/user-attachments/assets/da058aad-ea9f-484d-b154-77f729dedb46">


@jasongao97 Can I have your help with making the '*includes exclusive bookmark and sticker!' note on the same line with the "order direct" button? (now it's one line beneath the button)