### PR TITLE
Fix: Update resolvers to specifically target `screenshot.png` files

### DIFF
--- a/gatsby/create-resolvers.js
+++ b/gatsby/create-resolvers.js
@@ -32,6 +32,9 @@ module.exports = ({ createResolvers }) => {
                 relativeDirectory: {
                   eq: source.relativeDirectory,
                 },
+                base: {
+                  eq: 'screenshot.png',
+                },
                 internal: { mediaType: { regex: '/^(image)/' } },
               },
             },
@@ -51,6 +54,9 @@ module.exports = ({ createResolvers }) => {
               filter: {
                 relativeDirectory: {
                   eq: source.relativeDirectory,
+                },
+                base: {
+                  eq: 'screenshot.png',
                 },
                 internal: { mediaType: { regex: '/^(image)/' } },
               },


### PR DESCRIPTION
Updated Example and Exercise resolvers to specifically look for 'screenshot.png' files instead of any image in the directory. This ensures consistent behavior and makes it clear which file should be used as the screenshot.

```diff
Example: {
  screenshot: {
    type: 'File',
    resolve: async (source, args, context, info) => {
      const screenshot = await context.nodeModel.findOne({
        type: 'File',
        query: {
          filter: {
            relativeDirectory: {
              eq: source.relativeDirectory,
            },
+           base: {
+             eq: 'screenshot.png',
+           },
            internal: { mediaType: { regex: '/^(image)/' } },
          },
        },
      });
      return screenshot;
    },
  },
},
```
