### PR TITLE
Add missing 'this.' to code sample.

### DIFF
--- a/content/02_forces.html
+++ b/content/02_forces.html
@@ -158,7 +158,7 @@ mover.update();</pre>
 <p>This isn’t so great, since things become interesting only when I have objects with varying mass, but it’s enough to get us started. Where does mass come in? I need to divide force by mass to apply Newton’s second law to the object:</p>
 <pre class="codesplit" data-code-language="javascript">applyForce(force) {
   // Newton’s second law (with force accumulation and mass)
-  force.div(mass);
+  force.div(this.mass);
   this.acceleration.add(force);
 }</pre>
 <p>Yet again, even though the code looks quite reasonable, it has a major problem. Consider the following scenario with two <code>Mover</code> objects, both being blown away by a wind force:</p>


### PR DESCRIPTION
Fixes this sneaky monkey

![missing-this](https://github.com/user-attachments/assets/0c28e697-1484-4f34-abad-64f130650e4b)
