### PR TITLE
Fix: Bump @shopify/buy-button-js version to ^3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@loadable/component": "^5.16.4",
-        "@shopify/buy-button-js": "^2.4.0",
+        "@shopify/buy-button-js": "^3.0.5",
         "@tailwindcss/typography": "^0.5.4",
         "@typescript-eslint/eslint-plugin": "^6.7.3",
         "@typescript-eslint/parser": "^6.7.3",
@@ -4872,16 +4872,17 @@
       }
     },
     "node_modules/@shopify/buy-button-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@shopify/buy-button-js/-/buy-button-js-2.4.0.tgz",
-      "integrity": "sha512-JsNgo84mbew3rVrsQ4lPvfovm/i5lnB9Fqq1IvyEFSwkwjPr0xGR+MJFNpOrnsFKha52JW/5EtrQs2oyBrLDhA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@shopify/buy-button-js/-/buy-button-js-3.0.5.tgz",
+      "integrity": "sha512-OZ+9ZzEnv77Y4oYx8lSlnVcTqypPOPNJSy5sdVpyHBsiIJklzt4qFVlt/sZUZanIDA5RD3KE+TKk1vbii9XRvQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "7.18.9",
         "browserify": "16.3.0",
         "morphdom": "2.6.1",
         "mustache": "3.0.1",
-        "sass": "1.54.3",
-        "shopify-buy": "2.20.0",
+        "sass": "1.69.0",
+        "shopify-buy": "3.0.7",
         "uglify-js": "3.16.3"
       }
     },
@@ -4894,27 +4895,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@shopify/buy-button-js/node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw=="
-    },
-    "node_modules/@shopify/buy-button-js/node_modules/sass": {
-      "version": "1.54.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.3.tgz",
-      "integrity": "sha512-fLodey5Qd41Pxp/Tk7Al97sViYwF/TazRc5t6E65O7JOk4XF8pzwIW7CvCxYVOfJFFI/1x5+elDyBIixrp+zrw==",
-      "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@shopify/buy-button-js/node_modules/uglify-js": {
@@ -23436,9 +23416,10 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.62.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
-      "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.0.tgz",
+      "integrity": "sha512-l3bbFpfTOGgQZCLU/gvm1lbsQ5mC/WnLz3djL2v4WCJBDrWm58PO+jgngcGRNnKUh6wSsdm50YaovTqskZ0xDQ==",
+      "license": "MIT",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -23778,9 +23759,10 @@
       }
     },
     "node_modules/shopify-buy": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.20.0.tgz",
-      "integrity": "sha512-xe6VlqJtI/c8BYeH2hhOw7gZSsbHUeGFUwVyAzQOR422Ml4UXTFld0GcbW88tkR/Vgy2tj592EL2paCws2fZzQ=="
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-3.0.7.tgz",
+      "integrity": "sha512-HTuC8SSaVSFJRToXbrn54TSjxNt5d4GN//xfHXfHBJYSuHzGouF97CFapjdM+Pz5HjcGST6ife4B64GNo7taYw==",
+      "license": "MIT"
     },
     "node_modules/side-channel": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/nature-of-code/noc-notion#readme",
   "dependencies": {
     "@loadable/component": "^5.16.4",
-    "@shopify/buy-button-js": "^2.4.0",
+    "@shopify/buy-button-js": "^3.0.5",
     "@tailwindcss/typography": "^0.5.4",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",


### PR DESCRIPTION
Upgrade Shopify's buy button library to support latest the API.

<https://shopify.dev/changelog/deprecation-of-checkout-apis>