### PR TITLE
Gatsby v5 fix for images being cut-off

### DIFF
--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -3,7 +3,7 @@ import { GatsbyImage, getImage } from 'gatsby-plugin-image';
 
 const Image = (props) => {
   const image = getImage(props.image);
-  return <GatsbyImage image={image} alt={props.alt} />;
+  return <GatsbyImage image={image} alt={props.alt} objectFit="contain" />;
 };
 
 export default Image;


### PR DESCRIPTION
Hopefully this fixes a new issue where images are cut-off after upgrading to gatsby v5.